### PR TITLE
Allow for importing yaml string to replicator fields

### DIFF
--- a/src/Jobs/ImportJob.php
+++ b/src/Jobs/ImportJob.php
@@ -106,6 +106,14 @@ class ImportJob implements ShouldQueue
                     $value = Arr::wrap($value);
                 }
 
+                if ($field && !empty($value) && in_array($field->type(), $this->getSetFieldtypes())) {
+                    try {
+                        $value = YAML::parse($value);
+                    } catch (\Throwable $th) {
+                        // don't do anything. leave the value as is
+                    }
+                }
+
                 if (is_numeric($value)) {
                     $value += 0; // This returns int or float
                 }
@@ -199,6 +207,15 @@ class ImportJob implements ShouldQueue
             \Statamic\Fieldtypes\UserGroups::handle(),
             \Statamic\Fieldtypes\UserRoles::handle(),
             \Statamic\Fieldtypes\Users::handle(),
+        ];
+    }
+
+    private function getSetFieldtypes(): array
+    {
+        return [
+            // \Statamic\Fieldtypes\Bard::handle(),
+            \Statamic\Fieldtypes\Replicator::handle(),
+
         ];
     }
 }


### PR DESCRIPTION
I was trying to import a yaml string into a replicator field and the importer treated it as a string. This allows for yaml to be parsed and imported into the entry correctly in my case. Bard fields are left out because I have not yet had an instance to import into that kind of field